### PR TITLE
Creates 'lintFix' script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -p tsconfig.prod.json && vite build",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "lintFix": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0 --fix",
     "preview": "vite preview",
     "prepare": "husky install",
     "test": "NODE_ENV=test jest"


### PR DESCRIPTION
Instead of remembering to pass an extra flag: `npm run lint -- --fix`, you can now run `npm run lintFix`

